### PR TITLE
fix(auth): validate Spotify OAuth state server-side

### DIFF
--- a/srcs/backend/auth-service/src/controllers/oauth.controller.ts
+++ b/srcs/backend/auth-service/src/controllers/oauth.controller.ts
@@ -6,6 +6,7 @@ import {
   setAuthCookies,
   setSpotifyStateCookie,
 } from "../services/sessionCookies.service.js";
+import { storeOAuthState } from "../lib/oauthStateStore.js";
 
 /**
  *
@@ -55,7 +56,8 @@ export async function spotifyLogin(_req: Request, res: Response) {
 
   const state = base64Url(crypto.randomBytes(16));
 
-  // Store state in a cookie so we can validate it during the callback (CSRF protection).
+  storeOAuthState(state);
+  // Keep cookie for backwards compatibility; validation uses server-side store.
   setSpotifyStateCookie(res, state);
 
   const scope = ["user-read-email", "user-read-private", "user-top-read"].join(

--- a/srcs/backend/auth-service/src/lib/oauthStateStore.ts
+++ b/srcs/backend/auth-service/src/lib/oauthStateStore.ts
@@ -1,0 +1,31 @@
+const OAUTH_STATE_TTL_MS = 5 * 60 * 1000;
+
+const pendingStates = new Map<string, number>();
+
+function purgeExpiredStates(now = Date.now()): void {
+  for (const [state, expiresAt] of pendingStates) {
+    if (now > expiresAt) {
+      pendingStates.delete(state);
+    }
+  }
+}
+
+export function storeOAuthState(
+  state: string,
+  ttlMs = OAUTH_STATE_TTL_MS,
+): void {
+  purgeExpiredStates();
+  pendingStates.set(state, Date.now() + ttlMs);
+}
+
+export function consumeOAuthState(state: string): boolean {
+  purgeExpiredStates();
+  const expiresAt = pendingStates.get(state);
+  if (expiresAt === undefined) {
+    return false;
+  }
+
+  pendingStates.delete(state);
+
+  return Date.now() <= expiresAt;
+}

--- a/srcs/backend/auth-service/src/services/sessionCookies.service.ts
+++ b/srcs/backend/auth-service/src/services/sessionCookies.service.ts
@@ -79,5 +79,10 @@ export function setSpotifyStateCookie(res: Response, state: string) {
  * clearSpotifyStateCookie(res);
  */
 export function clearSpotifyStateCookie(res: Response) {
-  res.clearCookie("spotify_oauth_state", { path: "/" });
+  res.clearCookie("spotify_oauth_state", {
+    path: "/",
+    secure: true,
+    sameSite: "lax",
+    httpOnly: true,
+  });
 }

--- a/srcs/backend/auth-service/src/services/spotifyAuth.service.ts
+++ b/srcs/backend/auth-service/src/services/spotifyAuth.service.ts
@@ -10,6 +10,7 @@ import {
   getTopTracks,
   type SpotifyArtist,
 } from "../clients/spotify.client.js";
+import { consumeOAuthState } from "../lib/oauthStateStore.js";
 
 export type SpotifyCallbackInput = {
   code: string;
@@ -55,7 +56,7 @@ function buildTopGenres(
 export async function handleSpotifyCallback(
   input: SpotifyCallbackInput,
 ): Promise<SpotifyCallbackResult> {
-  if (!input.cookieState || input.cookieState !== input.returnedState) {
+  if (!consumeOAuthState(input.returnedState)) {
     throw new Error("INVALID_STATE");
   }
 


### PR DESCRIPTION
- Store OAuth state in memory to survive host mismatch between login and callback
- Stop relying on spotify_oauth_state cookie for CSRF validation
- Align cookie clearing options with secure attributes