### PR TITLE
fix: clean up match state after game ends

### DIFF
--- a/srcs/backend/game-service/src/services/match.service.ts
+++ b/srcs/backend/game-service/src/services/match.service.ts
@@ -47,9 +47,14 @@ export class MatchService {
   createMatch(input: CreateMatchInput): MatchState {
     const existingMatchId = this.userToMatch.get(input.userId);
     if (existingMatchId) {
-      throw new Error(
-        "You cannot create a new game because you are already in-game",
-      );
+      const existingMatch = this.matches.get(existingMatchId);
+      if (existingMatch?.phase === "finished") {
+        this.releasePlayersFromMatch(existingMatch);
+      } else {
+        throw new Error(
+          "You cannot create a new game because you are already in-game",
+        );
+      }
     }
 
     const matchId = this.generateMatchCode();
@@ -286,6 +291,8 @@ export class MatchService {
           emit,
           guessTimers: this.guessTimers,
           resumeTimers: this.resumeTimers,
+          onMatchFinished: (finishedMatch) =>
+            this.releasePlayersFromMatch(finishedMatch),
         });
       },
     );
@@ -329,6 +336,8 @@ export class MatchService {
       emit,
       guessTimers: this.guessTimers,
       resumeTimers: this.resumeTimers,
+      onMatchFinished: (finishedMatch) =>
+        this.releasePlayersFromMatch(finishedMatch),
     });
     return match;
   }
@@ -364,6 +373,7 @@ export class MatchService {
         matchId: match.matchId,
         scores: match.scores,
       });
+      this.releasePlayersFromMatch(match);
       return match;
     }
 
@@ -459,6 +469,10 @@ export class MatchService {
 
   getPlayerByUserId(userId: string): MatchPlayer | undefined {
     for (const match of this.matches.values()) {
+      if (match.phase === "finished") {
+        continue;
+      }
+
       const player = match.players.find(
         (p: MatchPlayer) => p.userId === userId,
       );
@@ -467,6 +481,12 @@ export class MatchService {
       }
     }
     return undefined;
+  }
+
+  private releasePlayersFromMatch(match: MatchState): void {
+    for (const player of match.players) {
+      this.userToMatch.delete(player.userId);
+    }
   }
 
   getMatchOrThrow(matchId: string): MatchState {

--- a/srcs/backend/game-service/src/services/round.ts
+++ b/srcs/backend/game-service/src/services/round.ts
@@ -55,6 +55,7 @@ export function resolveGuess({
   emit,
   guessTimers,
   resumeTimers,
+  onMatchFinished,
 }: ResolveGuessInput): void {
   clearTimer(guessTimers, match.matchId);
   clearTimer(resumeTimers, match.matchId);
@@ -111,6 +112,7 @@ export function resolveGuess({
             matchId: match.matchId,
             scores: match.scores,
           });
+          onMatchFinished?.(match);
           return;
         }
 

--- a/srcs/backend/game-service/src/types/round.d.ts
+++ b/srcs/backend/game-service/src/types/round.d.ts
@@ -9,4 +9,5 @@ export type ResolveGuessInput = {
   emit: EmitMatchEvent;
   guessTimers: MatchTimerMap;
   resumeTimers: MatchTimerMap;
+  onMatchFinished?: (match: MatchState) => void;
 };


### PR DESCRIPTION
- Clear active match state when leaving a finished game
- Properly disconnect player from finished matches
- Prevent stale "User is already playing state"
- Restore ability to create or join a new match after returning to Home