### PR TITLE
fix: properly clean up lobby state when leaving a room

### DIFF
--- a/srcs/backend/game-service/src/controllers/match.controller.ts
+++ b/srcs/backend/game-service/src/controllers/match.controller.ts
@@ -90,7 +90,11 @@ export function registerMatchHandlers(io: Server, socket: Socket): void {
   });
 
   socket.on("match:leave", () => {
-    const match = matchService.removeSocket(socket.id);
+    const userId = readHeader(socket.handshake.headers, "x-user-id");
+    const match = matchService.leaveMatch({
+      socketId: socket.id,
+      userId: userId ?? undefined,
+    });
 
     if (match) {
       socket.leave(match.matchId);

--- a/srcs/backend/game-service/src/services/match.service.ts
+++ b/srcs/backend/game-service/src/services/match.service.ts
@@ -48,13 +48,27 @@ export class MatchService {
     const existingMatchId = this.userToMatch.get(input.userId);
     if (existingMatchId) {
       const existingMatch = this.matches.get(existingMatchId);
-      if (existingMatch?.phase === "finished") {
-        this.releasePlayersFromMatch(existingMatch);
+      if (!existingMatch || existingMatch.phase === "finished") {
+        if (existingMatch) {
+          this.releasePlayersFromMatch(existingMatch);
+        }
       } else {
-        throw new Error(
-          "You cannot create a new game because you are already in-game",
+        const existingPlayer = existingMatch.players.find(
+          (player) => player.userId === input.userId,
         );
+        if (existingPlayer?.connected) {
+          throw new Error(
+            "You cannot create a new game because you are already in-game",
+          );
+        }
       }
+      this.userToMatch.delete(input.userId);
+    }
+
+    if (this.getPlayerByUserId(input.userId)) {
+      throw new Error(
+        "You cannot create a new game because you are already in-game",
+      );
     }
 
     const matchId = this.generateMatchCode();
@@ -93,6 +107,7 @@ export class MatchService {
       existingPlayer.connected = true;
       existingPlayer.disconnectedAt = null;
       ensureScoreEntry(match, existingPlayer);
+      this.userToMatch.set(input.userId, match.matchId);
       this.socketToMatch.set(input.socketId, match.matchId);
       return match;
     }
@@ -415,39 +430,37 @@ export class MatchService {
 
     const player = match.players.find((p) => p.socketId === socketId);
     if (player) {
-      this.userToMatch.delete(player.userId);
-      player.socketId = null;
-      player.connected = false;
-      player.disconnectedAt = new Date().toISOString();
-      console.log(
-        `Player ${player.userId} disconnected from match ${match.matchId}`,
-      );
+      this.detachPlayerFromMatch(player, match);
     }
 
     this.socketToMatch.delete(socketId);
 
-    // Corregido: Unificado en un único bloque limpio controlado por 'allDisconnected'
-    const allDisconnected = match.players.every((p) => !p.connected);
-    if (allDisconnected) {
-      console.log(
-        `All players disconnected. Match ${match.matchId} will be removed after timeout if no reconnection occurs.`,
-      );
+    return match;
+  }
 
-      global.setTimeout(() => {
-        const stillDisconnected = match.players.every((p) => !p.connected);
-        if (stillDisconnected) {
-          console.log(`Match ${match.matchId} removed due to inactivity.`);
-
-          const syncTimer = this.syncTimers.get(match.matchId);
-          if (syncTimer) global.clearTimeout(syncTimer);
-          this.syncTimers.delete(match.matchId);
-
-          this.matches.delete(match.matchId);
-        }
-      }, DISCONNECT_TTL_MS);
+  leaveMatch(input: { socketId: string; userId?: string }): MatchState | undefined {
+    const match = this.removeSocket(input.socketId);
+    if (match) {
+      return match;
     }
 
-    return match;
+    if (!input.userId) {
+      return undefined;
+    }
+
+    for (const currentMatch of this.matches.values()) {
+      const player = currentMatch.players.find(
+        (entry) => entry.userId === input.userId && entry.connected,
+      );
+      if (!player) {
+        continue;
+      }
+
+      this.detachPlayerFromMatch(player, currentMatch);
+      return currentMatch;
+    }
+
+    return undefined;
   }
 
   reconnectSocket(playerId: string, newSocketId: string): MatchState {
@@ -487,6 +500,49 @@ export class MatchService {
     for (const player of match.players) {
       this.userToMatch.delete(player.userId);
     }
+  }
+
+  private detachPlayerFromMatch(
+    player: MatchPlayer,
+    match: MatchState,
+  ): void {
+    if (player.socketId) {
+      this.socketToMatch.delete(player.socketId);
+    }
+
+    this.userToMatch.delete(player.userId);
+    player.socketId = null;
+    player.connected = false;
+    player.disconnectedAt = new Date().toISOString();
+    console.log(
+      `Player ${player.userId} disconnected from match ${match.matchId}`,
+    );
+
+    this.scheduleMatchRemovalIfEmpty(match);
+  }
+
+  private scheduleMatchRemovalIfEmpty(match: MatchState): void {
+    const allDisconnected = match.players.every((p) => !p.connected);
+    if (!allDisconnected) {
+      return;
+    }
+
+    console.log(
+      `All players disconnected. Match ${match.matchId} will be removed after timeout if no reconnection occurs.`,
+    );
+
+    global.setTimeout(() => {
+      const stillDisconnected = match.players.every((p) => !p.connected);
+      if (stillDisconnected) {
+        console.log(`Match ${match.matchId} removed due to inactivity.`);
+
+        const syncTimer = this.syncTimers.get(match.matchId);
+        if (syncTimer) global.clearTimeout(syncTimer);
+        this.syncTimers.delete(match.matchId);
+
+        this.matches.delete(match.matchId);
+      }
+    }, DISCONNECT_TTL_MS);
   }
 
   getMatchOrThrow(matchId: string): MatchState {

--- a/srcs/frontend/src/api/auth.ts
+++ b/srcs/frontend/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { apiJson } from "./http";
+import { apiJson, markSessionValidated, refreshSessionCookie, resetSessionValidation } from "./http";
 
 export type SpotifyArtist = {
   id: string;
@@ -49,7 +49,7 @@ export async function getMe(): Promise<AuthedUser> {
 }
 
 export async function refreshCookie(): Promise<void> {
-  await apiJson("/api/auth/refresh-cookie", { method: "POST" });
+  await refreshSessionCookie();
 }
 
 export async function login(email: string, password: string): Promise<void> {
@@ -57,12 +57,14 @@ export async function login(email: string, password: string): Promise<void> {
     method: "POST",
     body: JSON.stringify({ email, password }),
   });
-  localStorage.setItem("isLoggedIn", "true"); // 🟢 Listo para el próximo F5
+  localStorage.setItem("isLoggedIn", "true");
+  markSessionValidated();
 }
 
 export async function logout(): Promise<void> {
   await apiJson("/api/auth/logout", { method: "POST" });
-  localStorage.removeItem("isLoggedIn"); // 🟢 Limpieza absoluta
+  localStorage.removeItem("isLoggedIn");
+  resetSessionValidation();
 }
 
 export async function register(

--- a/srcs/frontend/src/api/http.ts
+++ b/srcs/frontend/src/api/http.ts
@@ -1,3 +1,108 @@
+const AUTH_PATHS_WITHOUT_401_RETRY = new Set([
+  "/api/auth/me",
+  "/api/auth/refresh-cookie",
+  "/api/auth/login",
+  "/api/auth/register",
+  "/api/auth/logout",
+]);
+
+// Must match access_token cookie maxAge in sessionCookies.service.ts (15 minutes).
+const ACCESS_TOKEN_MAX_AGE_MS = 15 * 60 * 1000;
+const SESSION_EXPIRES_AT_KEY = "sessionExpiresAt";
+const REFRESH_LOCK_KEY = "authRefreshLock";
+const REFRESH_LOCK_MAX_MS = 10_000;
+// Refresh before the cookie actually expires to avoid edge-case 401s.
+const REFRESH_BUFFER_MS = 90 * 1000;
+
+let refreshInFlight: Promise<void> | null = null;
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function tryAcquireRefreshLock(): boolean {
+  const now = Date.now();
+  const lock = localStorage.getItem(REFRESH_LOCK_KEY);
+  if (lock && now - Number(lock) < REFRESH_LOCK_MAX_MS) {
+    return false;
+  }
+  localStorage.setItem(REFRESH_LOCK_KEY, String(now));
+  return true;
+}
+
+function releaseRefreshLock() {
+  localStorage.removeItem(REFRESH_LOCK_KEY);
+}
+
+async function waitForOtherTabRefresh(maxWaitMs = REFRESH_LOCK_MAX_MS) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < maxWaitMs) {
+    if (!localStorage.getItem(REFRESH_LOCK_KEY)) {
+      return;
+    }
+    await sleep(50);
+  }
+}
+
+export function markSessionValidated() {
+  localStorage.setItem(
+    SESSION_EXPIRES_AT_KEY,
+    String(Date.now() + ACCESS_TOKEN_MAX_AGE_MS),
+  );
+}
+
+export function resetSessionValidation() {
+  localStorage.removeItem(SESSION_EXPIRES_AT_KEY);
+  localStorage.removeItem(REFRESH_LOCK_KEY);
+}
+
+async function ensureSessionFresh() {
+  if (localStorage.getItem("isLoggedIn") !== "true") return;
+
+  const expiresAt = Number(localStorage.getItem(SESSION_EXPIRES_AT_KEY) || 0);
+  if (expiresAt > Date.now() + REFRESH_BUFFER_MS) {
+    return;
+  }
+
+  await refreshSessionCookie();
+}
+
+export async function refreshSessionCookie(): Promise<void> {
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      if (!tryAcquireRefreshLock()) {
+        await waitForOtherTabRefresh();
+        return;
+      }
+
+      try {
+        const res = await apiFetch("/api/auth/refresh-cookie", {
+          method: "POST",
+        });
+        const data = await readResponseBody(res);
+
+        if (!res.ok) {
+          const message =
+            typeof data === "string"
+              ? data
+              : data && typeof data === "object" && "error" in data
+                ? String((data as { error?: unknown }).error)
+                : `HTTP_${res.status}`;
+          throw new Error(message);
+        }
+
+        markSessionValidated();
+      } finally {
+        releaseRefreshLock();
+      }
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+  }
+
+  return refreshInFlight;
+}
+
 export async function apiFetch(path: string, init: RequestInit = {}) {
   const res = await fetch(path, {
     ...init,
@@ -29,11 +134,26 @@ async function readResponseBody(res: Response) {
 export async function apiJson<T>(
   path: string,
   init: RequestInit = {},
+  retried = false,
 ): Promise<T> {
+  if (!retried && !AUTH_PATHS_WITHOUT_401_RETRY.has(path)) {
+    await ensureSessionFresh();
+  }
+
   const res = await apiFetch(path, init);
   const data = await readResponseBody(res);
 
   if (!res.ok) {
+    if (
+      res.status === 401 &&
+      !retried &&
+      !AUTH_PATHS_WITHOUT_401_RETRY.has(path)
+    ) {
+      resetSessionValidation();
+      await refreshSessionCookie();
+      return apiJson<T>(path, init, true);
+    }
+
     const message =
       typeof data === "string"
         ? data
@@ -54,6 +174,10 @@ export async function apiJsonPost<T>(
   payload: unknown,
   init: RequestInit = {},
 ): Promise<T> {
+  if (localStorage.getItem("isLoggedIn") === "true") {
+    await ensureSessionFresh();
+  }
+
   const res = await fetch(path, {
     ...init,
     method: "POST",

--- a/srcs/frontend/src/auth/AuthProvider.tsx
+++ b/srcs/frontend/src/auth/AuthProvider.tsx
@@ -1,43 +1,79 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { AuthContext, type AuthState } from "./auth-context";
 import { getMe, refreshCookie, type AuthedUser } from "../api/auth";
+import {
+  markSessionValidated,
+  resetSessionValidation,
+} from "../api/http";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthedUser | null>(null);
   const [loading, setLoading] = useState(true);
+  const loadSeqRef = useRef(0);
+  const inFlightLoadRef = useRef<Promise<void> | null>(null);
 
-  async function load() {
-    setLoading(true);
-
-    const isSpotifyRedirect = window.location.pathname.includes(
-      "/auth/spotify/success",
-    );
-    const hasLoginFlag = localStorage.getItem("isLoggedIn") === "true";
-
-    // 🟢 Si es un invitado común en el Home, salimos corriendo sin llamar al servidor (CERO 401s)
-    // 🟢 Pero si venimos rebotados de Spotify, la URL coincidirá y el IF nos dejará pasar a validar la cookie
-    if (!hasLoginFlag && !isSpotifyRedirect) {
-      setUser(null);
-      setLoading(false);
-      return;
+  async function load(options?: {
+    silent?: boolean;
+    forceFetch?: boolean;
+  }) {
+    if (inFlightLoadRef.current) {
+      return inFlightLoadRef.current;
     }
 
-    try {
-      const u = await getMe();
-      setUser(u);
-      localStorage.setItem("isLoggedIn", "true"); // Aseguramos el flag tras el éxito
-    } catch {
+    const seq = ++loadSeqRef.current;
+    const silent = options?.silent ?? false;
+    const forceFetch = options?.forceFetch ?? false;
+
+    const run = async () => {
+      if (!silent) setLoading(true);
+
+      const isSpotifyRedirect = window.location.pathname.includes(
+        "/auth/spotify/success",
+      );
+      const hasLoginFlag = localStorage.getItem("isLoggedIn") === "true";
+
+      // Si es un invitado común en el Home, salimos sin llamar al servidor (CERO 401s)
+      // Pero si venimos rebotados de Spotify, la URL coincidirá y el IF nos dejará pasar a validar la cookie
+      if (!forceFetch && !hasLoginFlag && !isSpotifyRedirect) {
+        if (seq === loadSeqRef.current) {
+          setUser(null);
+          if (!silent) setLoading(false);
+        }
+        return;
+      }
+
       try {
-        await refreshCookie();
         const u = await getMe();
+        if (seq !== loadSeqRef.current) return;
         setUser(u);
         localStorage.setItem("isLoggedIn", "true");
+        markSessionValidated();
       } catch {
-        setUser(null);
-        localStorage.removeItem("isLoggedIn");
+        try {
+          await refreshCookie();
+          const u = await getMe();
+          if (seq !== loadSeqRef.current) return;
+          setUser(u);
+          localStorage.setItem("isLoggedIn", "true");
+          markSessionValidated();
+        } catch {
+          if (seq !== loadSeqRef.current) return;
+          setUser(null);
+          localStorage.removeItem("isLoggedIn");
+          resetSessionValidation();
+        }
+      } finally {
+        if (seq === loadSeqRef.current && !silent) {
+          setLoading(false);
+        }
       }
+    };
+
+    inFlightLoadRef.current = run();
+    try {
+      await inFlightLoadRef.current;
     } finally {
-      setLoading(false);
+      inFlightLoadRef.current = null;
     }
   }
 
@@ -53,6 +89,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       clear: () => {
         setUser(null);
         localStorage.removeItem("isLoggedIn");
+        resetSessionValidation();
       },
     }),
     [user, loading],

--- a/srcs/frontend/src/pages/RoomLobbyPage.tsx
+++ b/srcs/frontend/src/pages/RoomLobbyPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useAuth } from "../auth/auth-context";
 import { socket } from "../api/socket";
@@ -31,9 +31,15 @@ export default function RoomLobbyPage() {
   const [matchState, setMatchState] = useState<MatchStatePayload | null>(
     createdMatch ?? null,
   );
-  // console.log("RoomLobby: createdMatch from location.state:", createdMatch);
 
   const [error, setError] = useState<string | null>(null);
+  const navigatingToMatchRef = useRef(false);
+
+  function leaveLobby() {
+    if (!socket.connected) return;
+    socket.emit("match:leave");
+  }
+
   const me = useMemo(() => {
     if (!matchState || !user) return null;
     const userId = String(user.id);
@@ -48,7 +54,8 @@ export default function RoomLobbyPage() {
   useEffect(() => {
     if (!user || !code) return;
 
-    // Connect if the socket is currently disconnected
+    navigatingToMatchRef.current = false;
+
     if (!socket.connected) {
       socket.connect();
     }
@@ -72,6 +79,7 @@ export default function RoomLobbyPage() {
       setError(null);
 
       if (payload.phase === "in-game") {
+        navigatingToMatchRef.current = true;
         nav(`/match/${code}`, { replace: true });
       }
     });
@@ -83,6 +91,7 @@ export default function RoomLobbyPage() {
       );
       setError(null);
       if (payload.phase === "in-game") {
+        navigatingToMatchRef.current = true;
         nav(`/match/${code}`, { replace: true });
       }
     });
@@ -96,6 +105,10 @@ export default function RoomLobbyPage() {
       socket.off("match:state");
       socket.off("match:phase");
       socket.off("match:error");
+
+      if (!navigatingToMatchRef.current) {
+        leaveLobby();
+      }
     };
   }, [code, user, nav, createdMatch]);
 
@@ -104,9 +117,7 @@ export default function RoomLobbyPage() {
   }
 
   function leave() {
-    if (socket.connected) {
-      socket.disconnect();
-    }
+    leaveLobby();
     nav("/", { replace: true });
   }
 


### PR DESCRIPTION
- Always emit `match:leave` when exiting the lobby
- Fix cleanup issues caused by React StrictMode
- Restore `userToMatch` on rejoin
- Remove stale match mappings when creating a new room
- Prevent false "User is already playing" errors after leaving a lobby